### PR TITLE
Simplify logic of from(unsigned)

### DIFF
--- a/ff/src/fields/models/small_fp/from.rs
+++ b/ff/src/fields/models/small_fp/from.rs
@@ -65,16 +65,7 @@ impl<P: SmallFpConfig> From<i32> for SmallFp<P> {
 
 impl<P: SmallFpConfig> From<u16> for SmallFp<P> {
     fn from(other: u16) -> Self {
-        let other_as_t = match P::T::try_from(other.into()) {
-            Ok(val) => val,
-            Err(_) => {
-                let modulus_as_u128: u128 = P::MODULUS.into();
-                let reduced = (other as u128) % modulus_as_u128;
-                P::T::try_from(reduced).unwrap_or_else(|_| panic!("Reduced value should fit in T"))
-            },
-        };
-        let val = other_as_t % P::MODULUS;
-        SmallFp::new(val)
+        Self::from(other as u128)
     }
 }
 
@@ -91,16 +82,7 @@ impl<P: SmallFpConfig> From<i16> for SmallFp<P> {
 
 impl<P: SmallFpConfig> From<u8> for SmallFp<P> {
     fn from(other: u8) -> Self {
-        let other_as_t = match P::T::try_from(other.into()) {
-            Ok(val) => val,
-            Err(_) => {
-                let modulus_as_u128: u128 = P::MODULUS.into();
-                let reduced = (other as u128) % modulus_as_u128;
-                P::T::try_from(reduced).unwrap_or_else(|_| panic!("Reduced value should fit in T"))
-            },
-        };
-        let val = other_as_t % P::MODULUS;
-        SmallFp::new(val)
+        Self::from(other as u128)
     }
 }
 

--- a/ff/src/fields/models/small_fp/from.rs
+++ b/ff/src/fields/models/small_fp/from.rs
@@ -3,7 +3,8 @@ use crate::{BigInt, PrimeField};
 
 impl<P: SmallFpConfig> From<u128> for SmallFp<P> {
     fn from(other: u128) -> Self {
-        let bigint = BigInt::<2>::new([other as u64, (other >> 64) as u64]);
+        let reduced_other = other % P::MODULUS_U128;
+        let bigint = BigInt::<2>::new([reduced_other as u64, (reduced_other >> 64) as u64]);
         Self::from_bigint(bigint).unwrap()
     }
 }


### PR DESCRIPTION
What does this PR do?

- calls `from(u128)` in functions: `from(u8)`, `from(u16)`, `from(u32)`, `from(u64)`
- performs reduction in `from(u128)` needed to match behavior of BigInt impl

```
    let test0 = M31::from(9991293939349493_u128);
    let test1 = SmallM31::from(9991293939349493_u128);
    println!("test0: {}", test0);
    println!("test1: {}", test1);
    
    output:
    test0: 1717630467
    test1: 1717630467
    
 ```
